### PR TITLE
off by one bug

### DIFF
--- a/dask_stitch/local_affine.py
+++ b/dask_stitch/local_affine.py
@@ -85,7 +85,7 @@ def merge_neighbors(
             for no, o in zip(neighbor_offset, overlap):
                 bs, ws = slice(None, None), slice(o, -o)
                 if no == -1:
-                    bs, ws = slice(0, o), slice(o, 0, -1)
+                    bs, ws = slice(0, o), slice(o-1, None, -1)
                 elif no == 1:
                     bs, ws = slice(-o, None), slice(-1, -o-1, -1) 
                 block_slc.append(bs)


### PR DESCRIPTION
To take the edge, one need to go all the way to None, and not to zero.  e.g.
[0,1,2,3,4,5,6][slice(3,0,1)] -- > [3, 2, 1]

[0,1,2,3,4,5,6][slice(3,None,1)] --> [3, 2, 1, 0]

See also:
https://github.com/GFleishman/bigstream/issues/8